### PR TITLE
feat: Add view modes, command info, and enhanced content

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,15 +7,37 @@
 <body>
     <div class="ai-editor">
         <div class="canvas">
-            <h1>Welcome to Your Page</h1>
-            <p>Click on any element to edit it with Dominique.</p>
-            <div>This is a sample editable div.</div>
+            <h1>Welcome to Your Editable Page</h1>
+            <p>This is a sample page. If you're in edit mode (e.g., by adding "?edit=1" to the URL), click on any element to modify it with the Dominique agent. Try selecting text to make it bigger, or this paragraph and ask Dominique to "change text to: I've been changed!".</p>
+
+            <div style="display: flex; margin-top: 20px; margin-bottom: 20px; background-color: #f9f9f9; padding:15px; border-radius: 5px;">
+                <div style="flex-basis: 50%; padding-right: 15px; box-sizing: border-box;">
+                    <h3>Dynamic Feature One</h3>
+                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Select this text to try styling it.</p>
+                </div>
+                <div style="flex-basis: 50%; padding-left: 15px; box-sizing: border-box; border-left: 1px solid #eee;">
+                    <h3>Interactive Service Two</h3>
+                    <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. You can change this content too.</p>
+                </div>
+            </div>
+
+            <div class="card">
+                <h3 class="card-title">Explore Our Platform</h3>
+                <p class="card-description">Discover the wide range of solutions and tools we offer to help you achieve your goals. Click the button to learn more about our innovative features.</p>
+                <button class="card-button">Discover Features</button>
+            </div>
+
+            <img src="https://via.placeholder.com/700x150.png?text=Sample+Banner+Image" alt="Sample Banner Image" style="max-width: 100%; height: auto; margin-top:20px; margin-bottom:20px; border-radius: 5px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+
+            <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. This final paragraph is also editable.</p>
         </div>
         <button id="saveButton">Save Page</button>
-        <div id="dominique-interface" style="display:none;">
+        <div id="dominique-interface">
+            <button id="dominique-info-button">i</button>
             <h3>Dominique Agent</h3>
             <input type="text" id="dominique-command-input">
             <button id="dominique-submit-button">Submit Command</button>
+            <div id="dominique-command-help" style="display: none;"></div>
         </div>
     </div>
     <script src="editor.js" defer></script>

--- a/style.css
+++ b/style.css
@@ -33,7 +33,15 @@ body {
     outline: none; /* Prevent browser default outline on contenteditable focus */
 }
 
-#saveButton {
+/* Hide editor-specific UI by default */
+#saveButton,
+#dominique-interface {
+    display: none;
+}
+
+/* Show editor-specific UI when in edit mode */
+.edit-mode-active #saveButton {
+    display: inline-block; /* Or block, depending on layout */
     padding: 10px 15px;
     background-color: #5cb85c;
     color: white;
@@ -55,6 +63,14 @@ body {
     box-shadow: 0 2px 10px rgba(0,0,0,0.1);
     margin-top: 10px;
 }
+
+/*
+   No specific rule for `.edit-mode-active #dominique-interface { display: block; }`
+   is needed here. The default `#dominique-interface { display: none; }` (above)
+   ensures it's hidden initially.
+   JavaScript's `activateDominiqueInterface()` and deselection logic
+   will handle setting `display: block` or `display: none` in edit mode.
+*/
 
 #dominique-interface h3 {
     margin-top: 0;
@@ -83,6 +99,72 @@ body {
 #dominique-submit-button:hover {
     background-color: #0056b3;
 }
+
+/* Dominique Info Button & Help Text */
+#dominique-interface {
+    position: relative; /* Needed for absolute positioning of the info button */
+}
+
+#dominique-info-button {
+    position: absolute;
+    top: 10px; /* Adjusted for padding of parent */
+    right: 10px; /* Adjusted for padding of parent */
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background-color: #6c757d; /* Grey color for info */
+    color: white;
+    border: none;
+    font-weight: bold;
+    text-align: center;
+    line-height: 22px; /* Vertically center the 'i' */
+    cursor: pointer;
+    font-size: 14px;
+    padding: 0; /* Remove any default padding */
+}
+
+#dominique-info-button:hover {
+    background-color: #5a6268;
+}
+
+#dominique-command-help {
+    background-color: #fff;
+    border: 1px solid #ccc;
+    padding: 15px;
+    margin-top: 10px; /* Space below the input/submit button */
+    border-radius: 4px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    font-size: 0.9em;
+}
+
+#dominique-command-help h4 {
+    margin-top: 0;
+    margin-bottom: 8px;
+    font-size: 1.1em;
+}
+
+#dominique-command-help ul {
+    list-style-type: none;
+    padding-left: 0;
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+#dominique-command-help li {
+    padding: 4px 0;
+    border-bottom: 1px solid #f0f0f0;
+}
+#dominique-command-help li:last-child {
+    border-bottom: none;
+}
+
+#dominique-command-help code {
+    background-color: #e9ecef;
+    padding: 2px 5px;
+    border-radius: 3px;
+    font-family: "Courier New", Courier, monospace;
+}
+
 
 /* 3. Styling for Created Components */
 


### PR DESCRIPTION
This commit introduces several major enhancements to the Dominique WYSIWYG editor:

1.  **View Modes:**
    *   The editor now supports a "normal view" (default) and an "edit view".
    *   Edit view is activated by appending `?edit=1` to the URL.
    *   Editor functionalities (Dominique UI, element selection, save button)
        are only available in edit view.

2.  **Command Info Icon:**
    *   Dominique's interface now includes an "i" (info) icon.
    *   Clicking this icon toggles a help panel displaying a list of
        available commands and their syntax, improving discoverability.

3.  **Enhanced Initial Page Content:**
    *   The default content of the editor canvas is now a more structured
        and varied sample page, including headings, paragraphs, a two-column
        layout, a sample card, and an image. This provides a richer
        starting point for you.

4.  **Conditional UI:**
    *   All editor-specific UI elements and JavaScript logic are strictly
        loaded/activated only when in edit mode.

These changes significantly improve the usability and structure of the application, aligning with recent feedback from you. Core functionalities like element selection, `contenteditable`, DOM manipulation commands, and page saving remain robust and are integrated into the new view mode system.