### PR TITLE
feat: Implement major UI/UX overhaul for Dominique editor

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -7,7 +7,6 @@ document.addEventListener('DOMContentLoaded', () => {
         document.body.classList.add('edit-mode-active');
         initializeEditor();
     } else {
-        // Optionally, hide editor elements explicitly if not using CSS only
         const editorElements = ['dominique-interface', 'saveButton'];
         editorElements.forEach(id => {
             const el = document.getElementById(id);
@@ -16,26 +15,102 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 });
 
+// Define help content string globally or within initializeEditor if preferred and passed around
+const COMMAND_HELP_HTML = `
+    <h4>Available Commands:</h4>
+    <ul>
+        <li><code>make text bigger</code></li>
+        <li><code>make text smaller</code></li>
+        <li><code>center text</code></li>
+        <li><code>change text to: [your new text]</code></li>
+        <li><code>create list: item1, item2, ...</code></li>
+        <li><code>create card: Title | Description | Button Text</code></li>
+        <li><code>create two columns</code></li>
+        <li><em>Type 'help' to see this list again.</em></li>
+    </ul>
+`;
+
 function initializeEditor() {
     const canvas = document.querySelector('.canvas');
     const dominiqueInterface = document.getElementById('dominique-interface');
     const commandInput = document.getElementById('dominique-command-input');
     let selectedElement = null;
 
-    // Function to activate and focus Dominique's interface
-    function activateDominiqueInterface() {
-        if (dominiqueInterface && commandInput) {
-            dominiqueInterface.style.display = 'block'; // Or 'flex'
-            commandInput.focus();
+    const dominiqueChatHistory = document.getElementById('dominique-chat-history');
+    const dominiqueInfoButton = document.getElementById('dominique-info-button');
+    // const dominiqueCommandHelp = document.getElementById('dominique-command-help'); // Removed
+    const dominiqueSubmitButton = document.getElementById('dominique-submit-button');
+    const dominiqueHeader = document.getElementById('dominique-header'); 
+
+    let isDragging = false;
+    let initialMouseX, initialMouseY;
+    let initialModalLeft, initialModalTop;
+
+    function scrollToBottom(element) {
+        if (element) {
+            element.scrollTop = element.scrollHeight;
+        }
+    }
+
+    function appendMessage(text, type, isHtml = false) {
+        if (!dominiqueChatHistory) {
+            console.error("Chat history element not found!");
+            return;
+        }
+        const messageDiv = document.createElement('div');
+        messageDiv.classList.add('chat-message', type);
+        if (isHtml) {
+            messageDiv.innerHTML = text; // Use innerHTML if content is HTML
         } else {
-            console.error("Dominique interface or command input not found for activation in edit mode.");
+            messageDiv.textContent = text; 
+        }
+        dominiqueChatHistory.appendChild(messageDiv);
+        scrollToBottom(dominiqueChatHistory);
+    }
+
+    function activateDominiqueInterface() {
+        if (!dominiqueInterface || !commandInput || !selectedElement) {
+            console.error("Dominique interface, command input, or selectedElement not found for activation.");
+            if (dominiqueInterface) dominiqueInterface.style.display = 'none'; 
+            return;
+        }
+        dominiqueInterface.style.display = 'flex'; 
+        const selectedRect = selectedElement.getBoundingClientRect();
+        const modalWidth = dominiqueInterface.offsetWidth;
+        const modalHeight = dominiqueInterface.offsetHeight;
+        const viewportWidth = window.innerWidth;
+        const viewportHeight = window.innerHeight;
+        const scrollX = window.scrollX;
+        const scrollY = window.scrollY;
+        const offset = 10; 
+        let modalTop = selectedRect.top + scrollY;
+        let modalLeft = selectedRect.right + scrollX + offset;
+        if (modalLeft + modalWidth > viewportWidth + scrollX) {
+            modalLeft = selectedRect.left + scrollX - modalWidth - offset; 
+        }
+        if (modalLeft < scrollX) {
+            modalLeft = scrollX + offset; 
+        }
+        if (modalTop + modalHeight > viewportHeight + scrollY) {
+            modalTop = selectedRect.bottom + scrollY - modalHeight; 
+            if (modalTop < scrollY) { 
+                 modalTop = scrollY + offset; 
+            }
+        }
+        if (modalTop < scrollY) {
+            modalTop = scrollY + offset; 
+        }
+        dominiqueInterface.style.top = `${modalTop}px`;
+        dominiqueInterface.style.left = `${modalLeft}px`;
+        commandInput.focus();
+        if (dominiqueChatHistory && dominiqueChatHistory.children.length === 0) {
+            appendMessage("Dominique is ready. Select an element and type a command, or type 'help'.", "system-message");
         }
     }
 
     if (canvas) {
         canvas.addEventListener('click', (event) => {
             const clickedElement = event.target;
-
             if (clickedElement === canvas) {
                 if (selectedElement) {
                     selectedElement.classList.remove('selected-highlight');
@@ -47,18 +122,13 @@ function initializeEditor() {
                 if (dominiqueInterface) dominiqueInterface.style.display = 'none';
                 return;
             }
-            
-            if (clickedElement === selectedElement) {
-                return;
-            }
-
+            if (clickedElement === selectedElement) return;
             if (selectedElement) {
                 selectedElement.classList.remove('selected-highlight');
                 if (selectedElement.contentEditable === 'true') {
                     selectedElement.contentEditable = 'false';
                 }
             }
-
             selectedElement = clickedElement;
             if (canvas.contains(selectedElement) && selectedElement !== canvas) {
                  selectedElement.classList.add('selected-highlight');
@@ -82,221 +152,171 @@ function initializeEditor() {
         console.error('Canvas element not found in edit mode!');
     }
 
-    const dominiqueSubmitButton = document.getElementById('dominique-submit-button');
-    const dominiqueInfoButton = document.getElementById('dominique-info-button');
-    const dominiqueCommandHelp = document.getElementById('dominique-command-help');
-
     if (dominiqueSubmitButton && commandInput) {
         dominiqueSubmitButton.addEventListener('click', (event) => {
             event.preventDefault();
             const commandText = commandInput.value.trim();
-            if (selectedElement && commandText) {
-                executeCommand(selectedElement, commandText);
-                commandInput.value = '';
-            } else if (!selectedElement) {
-                console.warn("No element selected. Please click on an element in the canvas first.");
-            } else if (!commandText) {
-                console.warn("Command input is empty. Please type a command.");
+            if (!commandText) {
+                appendMessage("Command input is empty. Please type a command.", "system-message");
+                return;
             }
+            if (!selectedElement && commandText.toLowerCase() !== "help") { 
+                appendMessage("No element selected. Please click on an element in the canvas first, or type 'help'.", "system-message");
+                return;
+            }
+            appendMessage(commandText, "user-message"); 
+            if (commandText.toLowerCase() === "help") {
+                appendMessage(COMMAND_HELP_HTML, "system-message", true); // Append HTML help
+            } else if (selectedElement) { 
+                executeCommand(selectedElement, commandText);
+                appendMessage(`Command processed: "${commandText}"`, "system-message"); 
+            } else {
+                appendMessage("Please select an element to apply this command or type 'help'.", "system-message");
+            }
+            commandInput.value = ''; 
+            commandInput.focus(); 
         });
     } else {
         if (!dominiqueSubmitButton) console.error('Dominique submit button not found in edit mode!');
         if (!commandInput) console.error('Dominique command input not found in edit mode!');
     }
 
-    if (dominiqueInfoButton && dominiqueCommandHelp) {
-        // Populate help content
-        dominiqueCommandHelp.innerHTML = `
-            <h4>Available Commands:</h4>
-            <ul>
-                <li><code>make text bigger</code></li>
-                <li><code>make text smaller</code></li>
-                <li><code>center text</code></li>
-                <li><code>change text to: [your new text]</code></li>
-                <li><code>create list: item1, item2, ...</code></li>
-                <li><code>create card: Title | Description | Button Text</code></li>
-                <li><code>create two columns</code></li>
-            </ul>
-        `;
-
-        // Add event listener to toggle help display
+    if (dominiqueInfoButton) { // Removed reference to dominiqueCommandHelp
         dominiqueInfoButton.addEventListener('click', () => {
-            const isHelpVisible = dominiqueCommandHelp.style.display === 'block';
-            dominiqueCommandHelp.style.display = isHelpVisible ? 'none' : 'block';
+            appendMessage(COMMAND_HELP_HTML, "system-message", true); // Append HTML help
         });
     } else {
         if (!dominiqueInfoButton) console.error('Dominique info button not found in edit mode!');
-        if (!dominiqueCommandHelp) console.error('Dominique command help div not found in edit mode!');
     }
 
+    if (dominiqueHeader && dominiqueInterface) {
+        dominiqueHeader.addEventListener('mousedown', (e) => {
+            isDragging = true;
+            initialMouseX = e.clientX;
+            initialMouseY = e.clientY;
+            initialModalLeft = dominiqueInterface.offsetLeft;
+            initialModalTop = dominiqueInterface.offsetTop;
+            document.body.style.userSelect = 'none'; 
+            dominiqueHeader.style.cursor = 'grabbing'; 
+            document.addEventListener('mousemove', onDragMouseMove);
+            document.addEventListener('mouseup', onDragMouseUp);
+            e.preventDefault(); 
+        });
+        function onDragMouseMove(e) {
+            if (!isDragging) return;
+            const deltaX = e.clientX - initialMouseX;
+            const deltaY = e.clientY - initialMouseY;
+            let newLeft = initialModalLeft + deltaX;
+            let newTop = initialModalTop + deltaY;
+            const viewportWidth = window.innerWidth;
+            const viewportHeight = window.innerHeight;
+            const modalWidth = dominiqueInterface.offsetWidth;
+            const modalHeight = dominiqueInterface.offsetHeight;
+            if (newLeft < 0) newLeft = 0;
+            if (newTop < 0) newTop = 0; 
+            if (newLeft + modalWidth > viewportWidth) newLeft = viewportWidth - modalWidth;
+            if (newTop + modalHeight > viewportHeight) newTop = viewportHeight - modalHeight;
+            dominiqueInterface.style.left = newLeft + 'px';
+            dominiqueInterface.style.top = newTop + 'px';
+        }
+        function onDragMouseUp() {
+            if (!isDragging) return;
+            isDragging = false;
+            document.removeEventListener('mousemove', onDragMouseMove);
+            document.removeEventListener('mouseup', onDragMouseUp);
+            document.body.style.userSelect = ''; 
+            dominiqueHeader.style.cursor = 'move'; 
+        }
+    } else {
+        if(!dominiqueHeader) console.error("Dominique header not found for dragging.");
+        if(!dominiqueInterface) console.error("Dominique interface not found for dragging.");
+    }
 
     function executeCommand(element, commandString) {
         console.log(`Executing command on element <${element.tagName.toLowerCase()}>: "${commandString}" in edit mode`);
-
         if (commandString.toLowerCase() === "make text bigger") {
             const currentSize = window.getComputedStyle(element).fontSize;
-            if (currentSize) {
-                element.style.fontSize = (parseFloat(currentSize) + 2) + 'px';
-            } else {
-                element.style.fontSize = '18px'; // Default if no current size
-            }
+            if (currentSize) element.style.fontSize = (parseFloat(currentSize) + 2) + 'px';
+            else element.style.fontSize = '18px'; 
         } else if (commandString.toLowerCase() === "make text smaller") {
             const currentSize = window.getComputedStyle(element).fontSize;
-            if (currentSize && parseFloat(currentSize) > 2) { // Prevent making text too small or negative
-                element.style.fontSize = (parseFloat(currentSize) - 2) + 'px';
-            } else if (currentSize && parseFloat(currentSize) <=2 ) {
-                console.warn("Text is already too small to reduce further.");
-            }
-            else {
-                 element.style.fontSize = '14px'; // Default if no current size
-            }
+            if (currentSize && parseFloat(currentSize) > 2) element.style.fontSize = (parseFloat(currentSize) - 2) + 'px';
+            else if (currentSize && parseFloat(currentSize) <=2 ) console.warn("Text is already too small to reduce further.");
+            else element.style.fontSize = '14px'; 
         } else if (commandString.toLowerCase() === "center text") {
             element.style.textAlign = 'center';
         } else if (commandString.toLowerCase().startsWith("change text to: ")) {
             const newText = commandString.substring("change text to: ".length).trim();
-            if (newText) {
-                element.innerText = newText;
-            } else {
-                console.warn("No text provided for 'change text to' command.");
-            }
+            if (newText) element.innerText = newText;
+            else console.warn("No text provided for 'change text to' command.");
         } else if (commandString.toLowerCase().startsWith("create list: ")) {
             const itemsString = commandString.substring("create list: ".length).trim();
             const items = itemsString.split(',').map(item => item.trim()).filter(item => item);
-
             if (items.length > 0) {
-                element.innerHTML = ''; // Clear existing content
+                element.innerHTML = ''; 
                 const ul = document.createElement('ul');
-                items.forEach(itemText => {
-                    const li = document.createElement('li');
-                    li.textContent = itemText;
-                    ul.appendChild(li);
-                });
+                items.forEach(itemText => { const li = document.createElement('li'); li.textContent = itemText; ul.appendChild(li); });
                 element.appendChild(ul);
-            } else {
-                console.warn("No items provided for 'create list' command. Format: create list: item1, item2");
-            }
+            } else console.warn("No items provided for 'create list' command. Format: create list: item1, item2");
         } else if (commandString.toLowerCase() === "create two columns") {
             createTwoColumns(element);
         } else if (commandString.toLowerCase().startsWith("create card: ")) {
             const paramsString = commandString.substring("create card: ".length).trim();
             const params = paramsString.split('|').map(p => p.trim());
-            if (params.length === 3) {
-                createCard(element, params[0], params[1], params[2]);
-            } else {
-                console.warn("Invalid format for 'create card'. Expected: create card: Title | Description | Button Text");
-            }
-        } else {
-            console.error("Unknown command: " + commandString);
-        }
+            if (params.length === 3) createCard(element, params[0], params[1], params[2]);
+            else console.warn("Invalid format for 'create card'. Expected: create card: Title | Description | Button Text");
+        } else console.error("Unknown command: " + commandString);
     }
 
     function createTwoColumns(element) {
-        const children = Array.from(element.childNodes); // Collect all child nodes
-        element.innerHTML = ''; // Clear the element
-
+        const children = Array.from(element.childNodes); 
+        element.innerHTML = ''; 
         const columnContainer = document.createElement('div');
-        columnContainer.style.display = 'flex'; // Use flexbox for columns
-        columnContainer.style.width = '100%'; // Container takes full width
-
+        columnContainer.style.display = 'flex'; columnContainer.style.width = '100%'; 
         const column1 = document.createElement('div');
-        column1.classList.add('column');
-        column1.style.flexBasis = '50%'; // Each column takes half
-        column1.style.boxSizing = 'border-box';
-        column1.style.padding = '10px';
-        // column1.style.border = '1px dashed #ccc'; // Basic styling, can be moved to CSS
-
+        column1.classList.add('column'); column1.style.flexBasis = '50%'; column1.style.boxSizing = 'border-box'; column1.style.padding = '10px';
         const column2 = document.createElement('div');
-        column2.classList.add('column');
-        column2.style.flexBasis = '50%';
-        column2.style.boxSizing = 'border-box';
-        column2.style.padding = '10px';
-        // column2.style.border = '1px dashed #ccc'; // Basic styling, can be moved to CSS
-
-        if (children.length === 0) {
-            column1.textContent = "Column 1";
-            column2.textContent = "Column 2";
-        } else {
+        column2.classList.add('column'); column2.style.flexBasis = '50%'; column2.style.boxSizing = 'border-box'; column2.style.padding = '10px';
+        if (children.length === 0) { column1.textContent = "Column 1"; column2.textContent = "Column 2"; }
+        else {
             const midpoint = Math.ceil(children.length / 2);
             children.forEach((child, index) => {
-                if (index < midpoint) {
-                    column1.appendChild(child.cloneNode(true)); // Append a clone to preserve original if needed elsewhere
-                } else {
-                    column2.appendChild(child.cloneNode(true));
-                }
+                if (index < midpoint) column1.appendChild(child.cloneNode(true)); 
+                else column2.appendChild(child.cloneNode(true));
             });
         }
-        
-        element.appendChild(columnContainer); // Append the container that holds the columns
-        columnContainer.appendChild(column1);
-        columnContainer.appendChild(column2);
+        element.appendChild(columnContainer); columnContainer.appendChild(column1); columnContainer.appendChild(column2);
         console.log(`Created two columns in element <${element.tagName.toLowerCase()}>`);
     }
 
     function createCard(element, title, description, buttonText) {
-        element.innerHTML = ''; // Clear the element
-
-        const cardDiv = document.createElement('div');
-        cardDiv.classList.add('card');
-
-        const titleElem = document.createElement('h3');
-        titleElem.classList.add('card-title');
-        titleElem.textContent = title;
-
-        const descElem = document.createElement('p');
-        descElem.classList.add('card-description');
-        descElem.textContent = description;
-
-        const buttonElem = document.createElement('button');
-        buttonElem.classList.add('card-button');
-        buttonElem.textContent = buttonText;
-
-        cardDiv.appendChild(titleElem);
-        cardDiv.appendChild(descElem);
-        cardDiv.appendChild(buttonElem);
-
+        element.innerHTML = ''; 
+        const cardDiv = document.createElement('div'); cardDiv.classList.add('card');
+        const titleElem = document.createElement('h3'); titleElem.classList.add('card-title'); titleElem.textContent = title;
+        const descElem = document.createElement('p'); descElem.classList.add('card-description'); descElem.textContent = description;
+        const buttonElem = document.createElement('button'); buttonElem.classList.add('card-button'); buttonElem.textContent = buttonText;
+        cardDiv.appendChild(titleElem); cardDiv.appendChild(descElem); cardDiv.appendChild(buttonElem);
         element.appendChild(cardDiv);
         console.log(`Created card in element <${element.tagName.toLowerCase()}> with title: "${title}"`);
     }
 
-    // Save Page functionality
     const saveButton = document.getElementById('saveButton');
-    if (saveButton && canvas) { // Ensure canvas is also available
+    if (saveButton && canvas) { 
         saveButton.addEventListener('click', () => {
-            // Deselect any element to remove highlights and contentEditable before saving
             if (selectedElement) {
                 selectedElement.classList.remove('selected-highlight');
-                if (selectedElement.contentEditable === 'true') {
-                    selectedElement.contentEditable = 'false';
-                }
+                if (selectedElement.contentEditable === 'true') selectedElement.contentEditable = 'false';
                 dominiqueInterface.style.display = 'none';
                 selectedElement = null;
             }
-
             const canvasContent = canvas.innerHTML;
-            const pageTitle = "My Saved Page"; // Or prompt user for a title
-
-            const fullHtml = `<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>${pageTitle}</title>
-    <!-- Optional: Include a way to link to a generic stylesheet or inline critical styles -->
-</head>
-<body>
-    ${canvasContent}
-</body>
-</html>`;
-
+            const pageTitle = "My Saved Page"; 
+            const fullHtml = `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>${pageTitle}</title></head><body>${canvasContent}</body></html>`;
             const blob = new Blob([fullHtml], { type: 'text/html' });
             const link = document.createElement('a');
-            link.href = URL.createObjectURL(blob);
-            link.download = 'saved_page.html';
-            document.body.appendChild(link); // Required for Firefox
-            link.click();
-            document.body.removeChild(link); // Clean up
-            URL.revokeObjectURL(link.href); // Clean up
-
+            link.href = URL.createObjectURL(blob); link.download = 'saved_page.html';
+            document.body.appendChild(link); link.click();
+            document.body.removeChild(link); URL.revokeObjectURL(link.href); 
             console.log("Page saved.");
         });
     } else {
@@ -304,28 +324,17 @@ function initializeEditor() {
         if (!canvas) console.error('Canvas element not found for saving in edit mode!');
     }
 
-    // isEditable needs to be accessible by the canvas click listener within initializeEditor
-    window.isEditable = function(element) { // Make it global or pass it around
+    window.isEditable = function(element) { 
         if (!element) return false;
         const tagName = element.tagName.toLowerCase();
         const nonEditableClasses = ['card', 'column', 'row']; 
         const editableTags = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'span', 'button'];
-
-        if (editableTags.includes(tagName)) {
-            return true;
-        }
-
+        if (editableTags.includes(tagName)) return true;
         if (tagName === 'div') {
-            for (const className of nonEditableClasses) {
-                if (element.classList.contains(className)) {
-                    return false;
-                }
-            }
+            for (const className of nonEditableClasses) if (element.classList.contains(className)) return false;
             const blockChildren = element.querySelectorAll('div, p, ul, h1, h2, h3, h4, h5, h6');
             if (blockChildren.length > 0) {
-                if (element.parentElement === canvas && blockChildren.length > 0) { // canvas needs to be in scope or passed
-                    return true;
-                }
+                if (element.parentElement === canvas && blockChildren.length > 0) return true;
                 if (element.classList.contains('card-description')) return true;
                 return false; 
             }

--- a/index.html
+++ b/index.html
@@ -5,7 +5,11 @@
     <link rel="stylesheet" type="text/css" href="style.css">
 </head>
 <body>
-    <div class="ai-editor">
+    <div id="editor-ui-container">
+        <button id="saveButton">Save Page</button>
+    </div>
+
+    <div class="ai-editor"> <!-- This remains as a wrapper for canvas if needed, or can be removed if .canvas is styled directly -->
         <div class="canvas">
             <h1>Welcome to Your Editable Page</h1>
             <p>This is a sample page. If you're in edit mode (e.g., by adding "?edit=1" to the URL), click on any element to modify it with the Dominique agent. Try selecting text to make it bigger, or this paragraph and ask Dominique to "change text to: I've been changed!".</p>
@@ -31,13 +35,18 @@
 
             <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. This final paragraph is also editable.</p>
         </div>
-        <button id="saveButton">Save Page</button>
-        <div id="dominique-interface">
+    </div>
+    <div id="dominique-interface">
+        <div id="dominique-header">
+            <span>Dominique Agent</span>
             <button id="dominique-info-button">i</button>
-            <h3>Dominique Agent</h3>
-            <input type="text" id="dominique-command-input">
-            <button id="dominique-submit-button">Submit Command</button>
-            <div id="dominique-command-help" style="display: none;"></div>
+        </div>
+        <div id="dominique-chat-history">
+            <!-- Chat messages will be appended here by JS -->
+        </div>
+        <div id="dominique-input-area">
+            <input type="text" id="dominique-command-input" placeholder="Type a command...">
+            <button id="dominique-submit-button">Send</button>
         </div>
     </div>
     <script src="editor.js" defer></script>

--- a/style.css
+++ b/style.css
@@ -14,10 +14,14 @@ body {
 }
 
 .canvas {
+    width: 800px;
+    margin: 20px auto; /* Added top/bottom margin for spacing from potential top bar */
     border: 1px solid #ccc;
     padding: 15px;
     min-height: 200px;
-    margin-bottom: 15px;
+    margin-bottom: 15px; /* This will be overridden by margin: auto for bottom if top bar is not tall */
+    background-color: #fff; /* Ensure canvas background is white if body is different */
+    box-shadow: 0 0 10px rgba(0,0,0,0.05); /* Softer shadow for the canvas itself */
 }
 
 .canvas > * { /* Direct children of canvas */
@@ -33,61 +37,32 @@ body {
     outline: none; /* Prevent browser default outline on contenteditable focus */
 }
 
-/* Hide editor-specific UI by default */
-#saveButton,
-#dominique-interface {
+/* Editor UI Container - Hidden by default */
+#editor-ui-container {
     display: none;
 }
 
-/* Show editor-specific UI when in edit mode */
-.edit-mode-active #saveButton {
-    display: inline-block; /* Or block, depending on layout */
-    padding: 10px 15px;
-    background-color: #5cb85c;
-    color: white;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    margin-bottom: 20px; /* Keep margin for spacing */
+/* Editor UI Container - Visible and styled in edit mode as a fixed top bar */
+.edit-mode-active #editor-ui-container {
+    display: block; /* Makes the container visible */
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 50px; /* Fixed height for the bar */
+    background-color: #333;
+    z-index: 1000;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.2);
 }
 
-#saveButton:hover {
-    background-color: #4cae4c;
-}
-
-/* 2. Dominique's Interface */
-#dominique-interface {
-    background-color: #f8f9fa;
-    padding: 15px;
-    border-radius: 5px;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-    margin-top: 10px;
-}
-
-/*
-   No specific rule for `.edit-mode-active #dominique-interface { display: block; }`
-   is needed here. The default `#dominique-interface { display: none; }` (above)
-   ensures it's hidden initially.
-   JavaScript's `activateDominiqueInterface()` and deselection logic
-   will handle setting `display: block` or `display: none` in edit mode.
-*/
-
-#dominique-interface h3 {
-    margin-top: 0;
-    margin-bottom: 10px;
-    font-size: 1.2em;
-}
-
-#dominique-command-input {
-    width: calc(100% - 22px); /* 100% - 2*10px padding - 2*1px border */
-    padding: 8px 10px;
-    margin-bottom: 10px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    box-sizing: border-box; /* Ensure padding and border are included in width calculation */
-}
-
-#dominique-submit-button {
+/* Save Button - Positioned inside the #editor-ui-container */
+/* This rule specifically targets #saveButton when it's inside an active #editor-ui-container */
+.edit-mode-active #editor-ui-container #saveButton {
+    display: inline-block; /* Make it visible */
+    position: absolute;
+    top: 50%;
+    right: 20px;
+    transform: translateY(-50%); /* Vertical centering */
     padding: 8px 15px;
     background-color: #007bff;
     color: white;
@@ -96,74 +71,119 @@ body {
     cursor: pointer;
 }
 
-#dominique-submit-button:hover {
+#saveButton:hover { /* General hover style for save button */
     background-color: #0056b3;
 }
 
-/* Dominique Info Button & Help Text */
+/* Dominique's Interface - Styled as a modal */
 #dominique-interface {
-    position: relative; /* Needed for absolute positioning of the info button */
+    display: none; 
+    position: absolute; 
+    width: 320px; /* Slightly wider to accommodate padding */
+    max-height: 400px;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15), 
+                0 0 3px 1px #ff00ff, 
+                0 0 6px 3px #00ffff, 
+                0 0 9px 5px #ffff00;
+    z-index: 999;
+    /* padding: 15px; /* Replaced by padding in individual sections */
+    display: flex; /* Use flex to structure header, chat, input area */
+    flex-direction: column;
 }
 
+#dominique-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 15px;
+    border-bottom: 1px solid #eee;
+    font-weight: bold;
+    cursor: move; /* Add cursor to indicate draggable header */
+}
+
+#dominique-chat-history {
+    flex-grow: 1; /* Takes up available vertical space */
+    overflow-y: auto;
+    padding: 10px 15px;
+    min-height: 100px; /* Minimum height before scrolling */
+    /* Max height is implicitly handled by #dominique-interface max-height and other flex children */
+}
+
+.chat-message {
+    margin-bottom: 8px;
+    word-wrap: break-word;
+    padding: 6px 10px;
+    border-radius: 7px;
+    line-height: 1.4;
+}
+
+.user-message {
+    text-align: right;
+    background-color: #dcf8c6; /* Light green for user */
+    margin-left: 20%;
+}
+
+.system-message {
+    text-align: left;
+    background-color: #f1f0f0; /* Light grey for system */
+    margin-right: 20%;
+}
+
+#dominique-input-area {
+    display: flex;
+    padding: 10px 15px;
+    border-top: 1px solid #eee;
+}
+
+#dominique-command-input { /* Already has some styles, this refines for flex context */
+    flex-grow: 1;
+    margin-right: 8px;
+    padding: 8px 10px; /* Existing padding */
+    border: 1px solid #ccc; /* Existing border */
+    border-radius: 4px; /* Existing radius */
+}
+
+#dominique-submit-button { /* Text changed to "Send" in HTML */
+    padding: 8px 15px; /* Existing padding */
+    /* background-color, color, border, border-radius, cursor are existing and fine */
+}
+
+
+/* Ensure canvas is also not overlapped by the fixed top bar */
+.ai-editor { /* Wrapper for canvas */
+    margin-top: 70px; /* Adjusted to match #dominique-interface's effective top position for consistency */
+}
+
+
+/* Dominique Info Button & Help Text - General Styles, position relative to #dominique-interface */
+/* Info button is now part of #dominique-header flex layout */
 #dominique-info-button {
-    position: absolute;
-    top: 10px; /* Adjusted for padding of parent */
-    right: 10px; /* Adjusted for padding of parent */
+    /* position: absolute; Removed */
+    /* top: 10px; Removed */
+    /* right: 10px; Removed */
     width: 22px;
     height: 22px;
     border-radius: 50%;
-    background-color: #6c757d; /* Grey color for info */
+    background-color: #6c757d;
     color: white;
     border: none;
     font-weight: bold;
     text-align: center;
-    line-height: 22px; /* Vertically center the 'i' */
+    line-height: 22px;
     cursor: pointer;
     font-size: 14px;
-    padding: 0; /* Remove any default padding */
+    padding: 0;
 }
 
 #dominique-info-button:hover {
     background-color: #5a6268;
 }
 
-#dominique-command-help {
-    background-color: #fff;
-    border: 1px solid #ccc;
-    padding: 15px;
-    margin-top: 10px; /* Space below the input/submit button */
-    border-radius: 4px;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
-    font-size: 0.9em;
-}
-
-#dominique-command-help h4 {
-    margin-top: 0;
-    margin-bottom: 8px;
-    font-size: 1.1em;
-}
-
-#dominique-command-help ul {
-    list-style-type: none;
-    padding-left: 0;
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-#dominique-command-help li {
-    padding: 4px 0;
-    border-bottom: 1px solid #f0f0f0;
-}
-#dominique-command-help li:last-child {
-    border-bottom: none;
-}
-
-#dominique-command-help code {
-    background-color: #e9ecef;
-    padding: 2px 5px;
-    border-radius: 3px;
-    font-family: "Courier New", Courier, monospace;
-}
+/* Styles for #dominique-command-help are now removed as the element is deleted. */
+/* The help content will be displayed directly in the chat history. */
 
 
 /* 3. Styling for Created Components */


### PR DESCRIPTION
This commit introduces a significant redesign of the Dominique editor's user interface and experience, based on detailed user feedback.

Key Changes:

1.  **Page Layout:**
    *   The main content canvas is now 800px wide and centered on the page.

2.  **Editor Top Bar:**
    *   A new fixed top bar (`#editor-ui-container`) is introduced, visible
        only in edit mode (`?edit=1`).
    *   The "Save Page" button is relocated to this top bar, positioned
        in the top-right corner.

3.  **Dominique as a Draggable Modal:**
    *   Dominique's interface (`#dominique-interface`) is now a modal dialog
        (300px wide, max 400px height) with a 3-color gradient box-shadow.
    *   The modal is dynamically positioned next to the selected HTML element,
        with logic to keep it within the viewport.
    *   The modal is draggable via its header.

4.  **Chat-Style Interface for Dominique:**
    *   The Dominique modal now features a chat-like interface:
        *   A scrollable history area displays your typed commands and
            system responses.
        *   An input field at the bottom is used for command entry.
    *   This provides clearer, contextual feedback for your actions.

5.  **Integrated Command Help:**
    *   The command help/info functionality is now integrated directly into
        the chat. Clicking the info icon or typing "help" displays the
        list of commands as a system message in the chat history.

These changes aim to provide a more intuitive, professional, and user-friendly editing experience. All previous core functionalities (element selection, contenteditable, DOM manipulation commands, view modes) have been maintained and integrated with this new UI/UX structure.