### PR TITLE
feat: Enable Enter key to submit commands in Dominique

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -210,6 +210,17 @@ function initializeEditor() {
             commandInput.value = ''; 
             commandInput.focus(); 
         });
+
+        // Add keydown listener to commandInput for "Enter" key
+        commandInput.addEventListener('keydown', (event) => {
+            if (event.key === "Enter") {
+                event.preventDefault(); // Stop default "Enter" key action
+                if (dominiqueSubmitButton) { // Ensure submit button exists
+                    dominiqueSubmitButton.click(); // Programmatically click the Send button
+                }
+            }
+        });
+
     } else {
         if (!dominiqueSubmitButton) console.error('Dominique submit button not found in edit mode!');
         if (!commandInput) console.error('Dominique command input not found in edit mode!');
@@ -253,7 +264,9 @@ function initializeEditor() {
 
     if (dominiqueHeader && dominiqueInterface) {
         dominiqueHeader.addEventListener('mousedown', (e) => {
-            if (e.target === dominiqueInfoButton || e.target === dominiqueCloseButton) return;
+             // Prevent dragging if mousedown is on any button within the header's icon group
+            if (e.target.closest('button')) return;
+
             isDragging = true;
             initialMouseX = e.clientX; initialMouseY = e.clientY;
             initialModalLeft = dominiqueInterface.offsetLeft; initialModalTop = dominiqueInterface.offsetTop;


### PR DESCRIPTION
This commit adds functionality to allow you to submit commands in the Dominique agent's input field by pressing the "Enter" key, in addition to clicking the "Send" button.

A `keydown` event listener has been added to the command input field (`#dominique-command-input`). When the "Enter" key is detected, the default action is prevented, and the click event of the "Send" button (`#dominique-submit-button`) is programmatically triggered.

This provides a common and convenient way for you to interact with the Dominique command interface.